### PR TITLE
Fix edit button to use correct test taker ID

### DIFF
--- a/WDP-FE/src/pages/ProfileUser/TestTakerList.tsx
+++ b/WDP-FE/src/pages/ProfileUser/TestTakerList.tsx
@@ -87,7 +87,9 @@ export default function TestTakerList() {
         <Space>
           <Button
             type='link'
-            onClick={() => navigate(`/test-takers/edit/${record.id}`)}
+            onClick={() => {
+              navigate(`/test-takers/edit/${record._id}`)
+            }}
           >
             Sửa
           </Button>


### PR DESCRIPTION
Updated the edit button's navigation to use `record._id` instead of `record.id` to ensure the correct test taker is referenced when editing.