### PR TITLE
Add bookingDate filter to service case queries

### DIFF
--- a/Backend/src/modules/manager/interfaces/imanager.repository.ts
+++ b/Backend/src/modules/manager/interfaces/imanager.repository.ts
@@ -15,6 +15,7 @@ export interface IManagerRepository {
   getAllServiceCasesWithoutSampleCollector(
     facilityId: string,
     isAtHome: boolean,
+    bookingDate: string,
   ): Promise<ServiceCase[]>
   managerCreateAccount(
     accountData: Partial<AccountDocument>,
@@ -22,7 +23,10 @@ export interface IManagerRepository {
     facilityId: string,
   ): Promise<AccountDocument>
   managerGetAllRoles(): Promise<RoleDocument[]>
-  getAllServiceCaseWithoutDoctor(facilityId: string): Promise<ServiceCase[]>
+  getAllServiceCaseWithoutDoctor(
+    facilityId: string,
+    bookingDate: string,
+  ): Promise<ServiceCase[]>
   assignDoctorToServiceCase(
     serviceCaseId: string,
     doctorId: string,

--- a/Backend/src/modules/manager/interfaces/imanager.service.ts
+++ b/Backend/src/modules/manager/interfaces/imanager.service.ts
@@ -13,6 +13,7 @@ export interface IManagerService {
   getAllServiceCasesWithoutSampleCollector(
     facilityId: string,
     isAtHome: boolean,
+    bookingDate: string,
   ): Promise<ServiceCaseResponseDto[]>
   managerCreateAccount(
     accountData: Partial<ManagerCreateAccountDto>,
@@ -22,6 +23,7 @@ export interface IManagerService {
   managerGetAllRoles(): Promise<RoleDocument[]>
   getAllServiceCaseWithoutDoctor(
     facilityId: string,
+    bookingDate: string,
   ): Promise<ServiceCaseResponseDto[]>
   assignDoctorToServiceCase(
     serviceCaseId: string,

--- a/Backend/src/modules/manager/manager.controller.ts
+++ b/Backend/src/modules/manager/manager.controller.ts
@@ -7,6 +7,7 @@ import {
   Param,
   Post,
   Put,
+  Query,
   Req,
   UseGuards,
 } from '@nestjs/common'
@@ -18,6 +19,7 @@ import {
   ApiBearerAuth,
   ApiParam,
   ApiBody,
+  ApiQuery,
 } from '@nestjs/swagger'
 
 import { IManagerService } from './interfaces/imanager.service'
@@ -68,6 +70,7 @@ export class ManagerController {
   @ApiBearerAuth()
   @Roles(RoleEnum.MANAGER)
   @ApiOperation({ summary: 'Lấy danh sách bác sĩ' })
+  @ApiQuery({ name: 'bookingDate', required: true, type: String })
   @ApiResponse({
     status: HttpStatus.OK,
     description: 'Danh sách bác sĩ',
@@ -111,15 +114,22 @@ export class ManagerController {
     }
   }
 
-  @Get('service-cases-without-sample-collector/:isAtHome')
+  @Get('service-cases-without-sample-collector')
   @ApiBearerAuth()
   @Roles(RoleEnum.MANAGER)
   @ApiOperation({ summary: 'Lấy danh sách hồ sơ chưa có nhân viên lấy mẫu' })
-  @ApiParam({
+  @ApiQuery({
     name: 'isAtHome',
     description: 'Lọc hồ sơ tại nhà (true) hoặc tại cơ sở (false)',
     required: false,
     type: Boolean,
+  })
+  @ApiQuery({
+    name: 'bookingDate',
+    required: true,
+    type: String,
+    description: 'Ngày đặt lịch ở định dạng YYYY-MM-DD',
+    example: '2025-07-22',
   })
   @ApiResponse({
     status: HttpStatus.OK,
@@ -129,13 +139,15 @@ export class ManagerController {
   })
   async getAllServiceCasesWithoutSampleCollector(
     @Req() req: any,
-    @Param('isAtHome') isAtHome: boolean = true, // Default to true if not provided
+    @Query('isAtHome') isAtHome: boolean = true,
+    @Query('bookingDate') bookingDate: string, // Default to true if not provided
   ): Promise<ApiResponseDto<ServiceCaseResponseDto>> {
     const facilityId = req.user.facility._id
     const data =
       await this.managerService.getAllServiceCasesWithoutSampleCollector(
         facilityId,
         isAtHome,
+        bookingDate,
       )
     return {
       statusCode: HttpStatus.OK,
@@ -149,12 +161,22 @@ export class ManagerController {
   @ApiBearerAuth()
   @Roles(RoleEnum.MANAGER)
   @ApiOperation({ summary: 'Lấy danh sách hồ sơ dịch vụ chưa có bác sĩ' })
+  @ApiQuery({
+    name: 'bookingDate',
+    required: true,
+    type: String,
+    description: 'Ngày đặt lịch ở định dạng YYYY-MM-DD',
+    example: '2025-07-22',
+  })
   async getAllServiceCaseWithoutDoctor(
     @Req() req: any,
+    @Query('bookingDate') bookingDate: string,
   ): Promise<ApiResponseDto<ServiceCaseResponseDto>> {
     const facilityId = req.user.facility._id
-    const data =
-      await this.managerService.getAllServiceCaseWithoutDoctor(facilityId)
+    const data = await this.managerService.getAllServiceCaseWithoutDoctor(
+      facilityId,
+      bookingDate,
+    )
     return {
       data: data.map((item) => new ServiceCaseResponseDto(item)),
       statusCode: HttpStatus.OK,

--- a/Backend/src/modules/manager/manager.repository.ts
+++ b/Backend/src/modules/manager/manager.repository.ts
@@ -180,16 +180,13 @@ export class ManagerRepository implements IManagerRepository {
   async getAllServiceCasesWithoutSampleCollector(
     facilityId: string,
     isAtHome: boolean,
+    bookingDate: string,
   ): Promise<ServiceCase[]> {
-    const serviceCaseStatus =
-      await this.testRequestStatusRepository.getTestRequestStatusIdByName(
-        'Đã thanh toán. Chờ đến lịch hẹn đến cơ sở để check-in (nếu quý khách chọn lấy mẫu tại nhà, không cần đến cơ sở để check-in)',
-      )
+    const bookingDateConvert = new Date(bookingDate)
     return await this.serviceCaseModel.aggregate([
       {
         $match: {
           sampleCollector: null,
-          currentStatus: new Types.ObjectId(serviceCaseStatus),
         },
       },
       // Ket noi voi casemembers
@@ -239,6 +236,11 @@ export class ManagerRepository implements IManagerRepository {
       // Mo mang bookings
       {
         $unwind: { path: '$bookings', preserveNullAndEmptyArrays: true },
+      },
+      {
+        $match: {
+          'bookings.bookingDate': bookingDateConvert, // Lọc theo ngày đặt lịch
+        },
       },
       // Ket noi voi slots
       {
@@ -351,16 +353,13 @@ export class ManagerRepository implements IManagerRepository {
 
   async getAllServiceCaseWithoutDoctor(
     facilityId: string,
+    bookingDate: string,
   ): Promise<ServiceCase[]> {
-    const serviceCaseStatus =
-      await this.testRequestStatusRepository.getTestRequestStatusIdByName(
-        'Đã nhận mẫu',
-      )
+    const bookingDateConvert = new Date(bookingDate)
     return await this.serviceCaseModel.aggregate([
       {
         $match: {
           doctor: null,
-          currentStatus: new Types.ObjectId(serviceCaseStatus),
         },
       },
       // Ket noi voi casemembers
@@ -404,6 +403,11 @@ export class ManagerRepository implements IManagerRepository {
       // Mo mang bookings
       {
         $unwind: { path: '$bookings', preserveNullAndEmptyArrays: true },
+      },
+      {
+        $match: {
+          'bookings.bookingDate': bookingDateConvert, // Lọc theo ngày đặt lịch
+        },
       },
       // Ket noi voi slots
       {

--- a/Backend/src/modules/manager/manager.service.ts
+++ b/Backend/src/modules/manager/manager.service.ts
@@ -48,11 +48,13 @@ export class ManagerService implements IManagerService {
   async getAllServiceCasesWithoutSampleCollector(
     facilityId: string,
     isAtHome: boolean,
+    bookingDate: string,
   ): Promise<ServiceCaseResponseDto[]> {
     const serviceCases =
       await this.managerRepository.getAllServiceCasesWithoutSampleCollector(
         facilityId,
         isAtHome,
+        bookingDate,
       )
     if (!serviceCases || serviceCases.length === 0) {
       throw new NotFoundException(
@@ -81,9 +83,13 @@ export class ManagerService implements IManagerService {
 
   async getAllServiceCaseWithoutDoctor(
     facilityId: string,
+    bookingDate: string,
   ): Promise<ServiceCaseResponseDto[]> {
     const serviceCases =
-      await this.managerRepository.getAllServiceCaseWithoutDoctor(facilityId)
+      await this.managerRepository.getAllServiceCaseWithoutDoctor(
+        facilityId,
+        bookingDate,
+      )
     if (!serviceCases || serviceCases.length === 0) {
       throw new NotFoundException('Không tìm thấy hồ sơ dịch vụ nào')
     }


### PR DESCRIPTION
Introduces a required bookingDate query parameter to endpoints and repository/service methods for fetching service cases without sample collectors or doctors. Aggregation pipelines now filter results by bookingDate, improving precision for date-specific queries.