### PR TITLE
Add password and role to manager account creation

### DIFF
--- a/Backend/src/modules/admin/admin.repository.ts
+++ b/Backend/src/modules/admin/admin.repository.ts
@@ -18,11 +18,13 @@ export class AdminRepository implements IAdminRepository {
   async createManagerAccount(
     accountData: Partial<Account>,
     userId: string,
+    managerRoleId: string,
   ): Promise<AccountDocument> {
     const createdManager = new this.accountModel({
       ...accountData,
       created_by: new Types.ObjectId(userId),
       created_at: new Date(),
+      role: new Types.ObjectId(managerRoleId),
     })
     return createdManager.save()
   }

--- a/Backend/src/modules/admin/admin.service.ts
+++ b/Backend/src/modules/admin/admin.service.ts
@@ -11,6 +11,7 @@ import { IRoleRepository } from '../role/interfaces/irole.repository'
 import { AccountResponseDto } from '../account/dto/accountResponse.dto'
 import { FacilityResponseDto } from '../facility/dto/facilityResponse.dto'
 import { isMongoId } from 'class-validator'
+import { Types } from 'mongoose'
 
 @Injectable()
 export class AdminService implements IAdminService {
@@ -72,7 +73,11 @@ export class AdminService implements IAdminService {
     if (!managerRoleId) {
       throw new NotFoundException('Role "Manager" không tồn tại')
     }
-    return this.adminRepository.createManagerAccount(createManagerDto, userId)
+    return this.adminRepository.createManagerAccount(
+      createManagerDto,
+      userId,
+      managerRoleId,
+    )
   }
 
   async deleteManagerAccount(

--- a/Backend/src/modules/admin/dto/createManager.dto.ts
+++ b/Backend/src/modules/admin/dto/createManager.dto.ts
@@ -13,6 +13,12 @@ export class CreateManagerDto {
   @IsNotEmpty({ message: 'Email không được để trống' })
   email: string
 
+  @ApiProperty({ example: 'securepass456', required: true, minLength: 6 })
+  @IsString()
+  @IsNotEmpty({ message: 'Mật khẩu không được để trống' })
+  @MinLength(6, { message: 'Mật khẩu phải có ít nhất 6 ký tự' })
+  password: string
+
   @ApiProperty({ example: '0987654321' })
   @IsString()
   @IsNotEmpty({ message: 'Số điện thoại không được để trống' })

--- a/Backend/src/modules/admin/interfaces/iadmin.repository.ts
+++ b/Backend/src/modules/admin/interfaces/iadmin.repository.ts
@@ -6,6 +6,7 @@ export interface IAdminRepository {
   createManagerAccount(
     accountData: Partial<AccountDocument>,
     userId: string,
+    managerRoleId: string,
   ): Promise<AccountDocument>
   deleteManagerAccount(
     id: string,


### PR DESCRIPTION
The manager account creation flow now requires a password and explicitly sets the manager role. Updated DTO, repository, service, and interface to support these changes for improved account security and role assignment.