### PR TITLE
Conditionally create kit shipment and comment out edit button

### DIFF
--- a/WDP-FE/src/components/ServiceAtHome/serviceAtHome.tsx
+++ b/WDP-FE/src/components/ServiceAtHome/serviceAtHome.tsx
@@ -131,12 +131,14 @@ const ServiceAtHomeForm: React.FC = () => {
         throw new Error('Không thể lấy caseMemberId')
       }
 
-      const kitShipmentData = {
-        caseMember: caseMemberId,
+      if (serviceDetail.isSelfSampling) {
+        const kitShipmentData = {
+            caseMember: caseMemberId,
+          }
+          const kitShipment = await createKitShipment(kitShipmentData).unwrap()
+          const kitShipmentId = kitShipment?.data?._id || kitShipment?._id
+          console.log('kitShipmentId:', kitShipmentId)
       }
-      const kitShipment = await createKitShipment(kitShipmentData).unwrap()
-      const kitShipmentId = kitShipment?.data?._id || kitShipment?._id
-      console.log('kitShipmentId:', kitShipmentId)
 
       const serviceCaseData = {
         caseMember: caseMemberId,

--- a/WDP-FE/src/pages/ProfileUser/ManageAddress.tsx
+++ b/WDP-FE/src/pages/ProfileUser/ManageAddress.tsx
@@ -311,13 +311,13 @@ export default function ManageAddress() {
       align: 'center',
       render: (_, record) => (
         <Space size='small'>
-          <Tooltip title='Chỉnh sửa'>
+          {/* <Tooltip title='Chỉnh sửa'>
             <Button
               type='text'
               icon={<EditOutlined />}
               onClick={() => handleEditAddressClick(record)}
             />
-          </Tooltip>
+          </Tooltip> */}
           <Tooltip title='Xóa'>
             <Popconfirm
               title='Xác nhận xóa'


### PR DESCRIPTION
Kit shipment creation in ServiceAtHomeForm is now conditional on isSelfSampling. The edit address button in ManageAddress is commented out, leaving only the delete option visible.