### PR TITLE
Include email in delivery staff aggregation result

### DIFF
--- a/Backend/src/modules/deliveryStaff/deliveryStaff.repository.ts
+++ b/Backend/src/modules/deliveryStaff/deliveryStaff.repository.ts
@@ -256,6 +256,7 @@ export class DeliveryStaffRepository implements IDeliveryStaffRepository {
             _id: '$accountDetails._id',
             name: '$accountDetails.name',
             phoneNumber: '$accountDetails.phoneNumber',
+            email: '$accountDetails.email',
           },
           bookingDate: '$bookings.bookingDate',
           timeReturn: '$timeReturns.timeReturn',


### PR DESCRIPTION
Added the email field from accountDetails to the aggregation projection in DeliveryStaffRepository. This allows the email address to be included in the query results for delivery staff.