### PR TITLE
Add booking date display to service case list

### DIFF
--- a/Backend/src/modules/serviceCase/serviceCase.service.ts
+++ b/Backend/src/modules/serviceCase/serviceCase.service.ts
@@ -55,6 +55,7 @@ export class ServiceCaseService implements IServiceCaseService {
         : null,
       sampleCollector: serviceCase.sampleCollector,
       doctor: serviceCase.doctor,
+      caseMember: serviceCase.caseMember,
     })
   }
 
@@ -119,6 +120,14 @@ export class ServiceCaseService implements IServiceCaseService {
       this.serviceCaseRepository.countDocuments(filter),
       this.serviceCaseRepository
         .findAllServiceCases(filter)
+        .populate({
+          path: 'caseMember',
+          select: 'booking',
+          populate: {
+            path: 'booking',
+            select: 'bookingDate'
+          },
+        })
         .skip(skip)
         .limit(pageSize),
     ])

--- a/WDP-FE/src/pages/ProfileUser/ServiceCase.tsx
+++ b/WDP-FE/src/pages/ProfileUser/ServiceCase.tsx
@@ -172,6 +172,21 @@ export default function ServiceCase() {
       },
     },
     {
+      title: 'Ngày đặt',
+      key: 'bookingDate',
+      render: (
+        _: any,
+        record: { caseMember: { booking: { bookingDate: string } } }
+      ) => {
+        const bookingDate = record.caseMember?.booking?.bookingDate
+        if (!bookingDate) return <Tag color='default'>Chưa đặt</Tag>
+        const date = new Date(bookingDate)
+        return (
+          <Typography.Text>{date.toLocaleDateString('vi-VN')}</Typography.Text>
+        )
+      },
+    },
+    {
       title: 'Nhân viên lấy mẫu',
       key: 'sampleCollector',
       dataIndex: ['sampleCollector', 'name'], // Giúp cho việc sắp xếp theo tên
@@ -271,7 +286,9 @@ export default function ServiceCase() {
       key: 'action',
       render: (_: any, record: any) => (
         <Space direction='vertical'>
-          <Button onClick={() => navigate(`/service-case-customer/${record._id}`)}>
+          <Button
+            onClick={() => navigate(`/service-case-customer/${record._id}`)}
+          >
             Xem chi tiết
           </Button>
           {/* <Button


### PR DESCRIPTION
Extended the backend to populate 'caseMember' with booking and bookingDate fields. Updated the frontend to show the booking date in the service case table, displaying a default tag if not booked.