### PR TITLE
Add sampleIdentifyNumbers GUIDs to CaseMember

### DIFF
--- a/Backend/src/modules/caseMember/dto/caseMemberResponse.dto.ts
+++ b/Backend/src/modules/caseMember/dto/caseMemberResponse.dto.ts
@@ -54,6 +54,14 @@ export class CaseMemberResponseDto {
   slot: mongoose.Types.ObjectId
 
   @Expose()
+  @ApiProperty({
+    example: ['12345', '123456'],
+    type: [String],
+  })
+  @Transform(transformObjectIdArray, { toPlainOnly: true })
+  sampleIdentifyNumbers: string[]
+
+  @Expose()
   @ApiProperty({ example: '605e3f5f4f3e8c1d4c9f1e1a', type: String })
   @Transform(transformObjectId, { toPlainOnly: true })
   created_by: mongoose.Types.ObjectId

--- a/Backend/src/modules/caseMember/schemas/caseMember.schema.ts
+++ b/Backend/src/modules/caseMember/schemas/caseMember.schema.ts
@@ -65,6 +65,9 @@ export class CaseMember extends BaseEntity {
     required: true,
   })
   address: mongoose.Schema.Types.ObjectId
+
+  @Prop({ type: [String], default: [] })
+  sampleIdentifyNumbers: string[]
 }
 
 export const CaseMemberSchema = SchemaFactory.createForClass(CaseMember)


### PR DESCRIPTION
Introduces sampleIdentifyNumbers as an array of GUIDs for each case member, generated based on service usage logic. Updates the service, DTO, and schema to support storing and returning these identifiers.