### PR TITLE
Integrate TestRequestStatus into AdnDocumentation

### DIFF
--- a/Backend/src/modules/adnDocumentation/adnDocumentation.module.ts
+++ b/Backend/src/modules/adnDocumentation/adnDocumentation.module.ts
@@ -9,6 +9,7 @@ import {
 import { AdnDocumentationService } from './adnDocumentation.service'
 import { IAdnDocumentationService } from './interfaces/iadnDocumentation.service'
 import { ServiceCaseModule } from '../serviceCase/serviceCase.module'
+import { TestRequestStatusModule } from '../testRequestStatus/testRequestStatus.module'
 
 @Module({
   imports: [
@@ -16,6 +17,7 @@ import { ServiceCaseModule } from '../serviceCase/serviceCase.module'
       { name: AdnDocumentation.name, schema: AdnDocumentationSchema },
     ]),
     ServiceCaseModule,
+    TestRequestStatusModule,
   ],
   providers: [
     {


### PR DESCRIPTION
Added TestRequestStatusModule to AdnDocumentationModule and injected ITestRequestStatusRepository into AdnDocumentationService. Updated the create method to set the service case status to 'Chờ duyệt kết quả' after creating a new ADN documentation.