### PR TITLE
Refactor service case queries and booking details structure

### DIFF
--- a/Backend/src/modules/doctor/doctor.controller.ts
+++ b/Backend/src/modules/doctor/doctor.controller.ts
@@ -173,11 +173,9 @@ export class DoctorController {
     @Query('currentStatus') currentStatus: string,
     @Query('resultExists') resultExists: boolean, // Default to false if not provided
   ): Promise<ApiResponseDto<ServiceCaseResponseDto>> {
-    const facilityId = req.user.facility._id
     const doctorId = req.user.id // Assuming the user is a doctor
     const data =
       await this.doctorService.getAllServiceCasesWithoutAdnDocumentation(
-        facilityId,
         doctorId,
         currentStatus,
         resultExists,

--- a/Backend/src/modules/doctor/doctor.repository.ts
+++ b/Backend/src/modules/doctor/doctor.repository.ts
@@ -15,7 +15,6 @@ export class DoctorRepository implements IDoctorRepository {
   ) {}
 
   async getAllServiceCasesWithoutAdnDocumentation(
-    facilityId: string,
     doctorId: string,
     currentStatus: string,
     resultExists: boolean,
@@ -129,56 +128,6 @@ export class DoctorRepository implements IDoctorRepository {
           preserveNullAndEmptyArrays: true,
         },
       },
-      // Mo bang slotTemplates
-      {
-        $lookup: {
-          from: 'slottemplates',
-          let: { slotTemplateId: '$slots.slotTemplate' },
-          pipeline: [
-            {
-              $match: {
-                $expr: {
-                  $eq: ['$_id', '$$slotTemplateId'],
-                },
-              },
-            },
-          ],
-          as: 'slotTemplates',
-        },
-      },
-      // Mo mang slotTemplates
-      {
-        $unwind: { path: '$slotTemplates', preserveNullAndEmptyArrays: true },
-      },
-      // Mo bang facilities
-      {
-        $lookup: {
-          from: 'facilities',
-          let: { facilityId: '$slotTemplates.facility' },
-          pipeline: [
-            {
-              $match: {
-                $expr: {
-                  $and: [
-                    { $eq: ['$_id', '$$facilityId'] },
-                    { $eq: ['$_id', new Types.ObjectId(facilityId)] },
-                  ],
-                },
-              },
-            },
-          ],
-          as: 'facilities',
-        },
-      },
-      // Mo bang facilities
-      {
-        $unwind: { path: '$facilities', preserveNullAndEmptyArrays: true },
-      },
-      {
-        $match: {
-          'facilities._id': new Types.ObjectId(facilityId), // Loc theo facilityId
-        },
-      },
       {
         $lookup: {
           from: 'testtakers',
@@ -220,7 +169,10 @@ export class DoctorRepository implements IDoctorRepository {
         $project: {
           _id: 1,
           currentStatus: '$currentStatus.testRequestStatus',
-          bookingDate: '$bookings.bookingDate',
+          bookingDetails: {
+            bookingDate: '$bookings.bookingDate',
+            slotTime: '$slots.startTime',
+          },
           accountDetails: {
             _id: '$accountDetails._id',
             name: '$accountDetails.name',

--- a/Backend/src/modules/doctor/doctor.service.ts
+++ b/Backend/src/modules/doctor/doctor.service.ts
@@ -19,14 +19,12 @@ export class DoctorService implements IDoctorService {
   ) {}
 
   async getAllServiceCasesWithoutAdnDocumentation(
-    facilityId: string,
     doctorId: string,
     currentStatus: string,
     resultExists: boolean,
   ): Promise<ServiceCaseResponseDto[]> {
     const serviceCases =
       await this.doctorRepository.getAllServiceCasesWithoutAdnDocumentation(
-        facilityId,
         doctorId,
         currentStatus,
         resultExists,

--- a/Backend/src/modules/doctor/interfaces/idoctor.repository.ts
+++ b/Backend/src/modules/doctor/interfaces/idoctor.repository.ts
@@ -2,7 +2,6 @@ import { ServiceCaseDocument } from 'src/modules/serviceCase/schemas/serviceCase
 
 export interface IDoctorRepository {
   getAllServiceCasesWithoutAdnDocumentation(
-    facilityId: string,
     doctorId: string,
     currentStatus: string,
     resultExists: boolean,

--- a/Backend/src/modules/doctor/interfaces/idoctor.service.ts
+++ b/Backend/src/modules/doctor/interfaces/idoctor.service.ts
@@ -3,7 +3,6 @@ import { TestRequestStatusDocument } from 'src/modules/testRequestStatus/schemas
 
 export interface IDoctorService {
   getAllServiceCasesWithoutAdnDocumentation(
-    facilityId: string,
     doctorId: string,
     currentStatus: string,
     resultExists: boolean,

--- a/Backend/src/modules/sampleCollector/sampleCollector.repository.ts
+++ b/Backend/src/modules/sampleCollector/sampleCollector.repository.ts
@@ -155,6 +155,21 @@ export class SampleCollectorRepository implements ISampleCollectorRepository {
       {
         $unwind: { path: '$bookingDetails', preserveNullAndEmptyArrays: true },
       },
+      {
+        $lookup: {
+          from: 'slots',
+          let: { slotId: '$bookingDetails.slot' },
+          pipeline: [
+            {
+              $match: { $expr: { $eq: ['$_id', '$$slotId'] } },
+            },
+          ],
+          as: 'slotDetails',
+        },
+      },
+      {
+        $unwind: { path: '$slotDetails', preserveNullAndEmptyArrays: true },
+      },
       // Mo bang services
       {
         $lookup: {
@@ -186,7 +201,10 @@ export class SampleCollectorRepository implements ISampleCollectorRepository {
         $project: {
           _id: 1,
           currentStatus: '$statusDetails.testRequestStatus',
-          bookingDate: '$bookingDetails.bookingDate',
+          bookingDetails: {
+            bookingDate: '$bookingDetails.bookingDate',
+            slotTime: '$slotDetails.startTime',
+          },
           accountDetails: {
             _id: '$accountDetails._id',
             name: '$accountDetails.name',


### PR DESCRIPTION
Removed facilityId filtering from doctor service case queries and related interfaces, simplifying method signatures and aggregation pipelines. Updated booking details projection to include slot time in both doctor and sample collector repositories for more comprehensive booking information.