### PR TITLE
Add image and service case queries by creator and collector

### DIFF
--- a/Backend/src/modules/image/image.controller.ts
+++ b/Backend/src/modules/image/image.controller.ts
@@ -169,13 +169,6 @@ export class ImageController {
     }
   }
 
-  @Get(':id')
-  @ApiParam({ name: 'id', required: true })
-  async findById(@Param('id') id: string) {
-    const image = await this.uploadService.findById(id)
-    return image
-  }
-
   @Get('findForBlog/:blogId')
   async findAllForBlog(@Param('blogId') blogId: string) {
     return this.uploadService.findAllForBlog(blogId)
@@ -184,6 +177,21 @@ export class ImageController {
   @Get('findForServiceCase/:serviceCaseId')
   async findAllForServiceCase(@Param('serviceCaseId') serviceCaseId: string) {
     return this.uploadService.findAllForServiceCase(serviceCaseId)
+  }
+
+  @Get('findForServiceCaseByCreatedBy')
+  @UseGuards(AuthGuard)
+  @ApiBearerAuth()
+  async findByCreatedBy(@Req() req: any) {
+    const userId = req.user.id
+    return this.uploadService.findByCreatedBy(userId)
+  }
+
+  @Get(':id')
+  @ApiParam({ name: 'id', required: true })
+  async findById(@Param('id') id: string) {
+    const image = await this.uploadService.findById(id)
+    return image
   }
 
   @Get('findForKitShipment/:kitShipmentId')

--- a/Backend/src/modules/image/imageUpload.repository.ts
+++ b/Backend/src/modules/image/imageUpload.repository.ts
@@ -127,4 +127,11 @@ export class ImageUploadRepository implements IImageUploadRepository {
       .exec()
     return result
   }
+
+  async findByCreatedBy(userId: string): Promise<ImageDocument[]> {
+    return await this.imageModel
+      .find({ created_by: userId, deleted_at: null })
+      .lean()
+      .exec()
+  }
 }

--- a/Backend/src/modules/image/imageUpload.service.ts
+++ b/Backend/src/modules/image/imageUpload.service.ts
@@ -195,4 +195,14 @@ export class ImageUploadService implements IImageUploadService {
     await this.imageModel.deleteById(id, userId)
     return true
   }
+
+  async findByCreatedBy(userId: string): Promise<ImageDocument[]> {
+    const data = await this.imageModel.findByCreatedBy(userId)
+
+    if (!data) {
+      throw new NotFoundException('Không tìm thấy ảnh nào')
+    }
+
+    return data
+  }
 }

--- a/Backend/src/modules/image/interfaces/iImageUpload.service.ts
+++ b/Backend/src/modules/image/interfaces/iImageUpload.service.ts
@@ -40,6 +40,8 @@ export interface IImageUploadService {
   findById(id: string): Promise<ImageDocument | null>
 
   deleteById(id: string, userId: string): Promise<boolean>
+
+  findByCreatedBy(userId: string): Promise<ImageDocument[]>
 }
 
 export const IImageUploadService = Symbol('IImageUploadService')

--- a/Backend/src/modules/image/interfaces/iimageUpload.repository.ts
+++ b/Backend/src/modules/image/interfaces/iimageUpload.repository.ts
@@ -39,6 +39,8 @@ export interface IImageUploadRepository {
   findAllImageForKitShipment(kitShipmentId: string): Promise<ImageDocument[]>
 
   findAllImageForResult(kitShipmentId: string): Promise<ImageDocument[]>
+
+  findByCreatedBy(userId: string): Promise<ImageDocument[]>
 }
 
 export const IImageUploadRepository = Symbol('IImageUploadRepository')

--- a/Backend/src/modules/sampleCollector/interfaces/isampleCollector.service.ts
+++ b/Backend/src/modules/sampleCollector/interfaces/isampleCollector.service.ts
@@ -10,6 +10,10 @@ export interface ISampleCollectorService {
   getAllServiceCaseStatusForSampleCollector(): Promise<
     TestRequestStatusDocument[]
   >
+  getAllServiceCasesForSampleCollector(
+    sampleCollectorId: string,
+    isAtHome: boolean,
+  ): Promise<ServiceCaseDocument[]>
 }
 
 export const ISampleCollectorService = Symbol('ISampleCollectorService')

--- a/Backend/src/modules/sampleCollector/sampleCollector.controller.ts
+++ b/Backend/src/modules/sampleCollector/sampleCollector.controller.ts
@@ -92,4 +92,31 @@ export class SampleCollectorController {
       success: true,
     })
   }
+
+  @Get('all-service-cases')
+  @ApiBearerAuth('bearer')
+  @Roles(RoleEnum.SAMPLE_COLLECTOR)
+  @ApiQuery({
+    name: 'isAtHome',
+    required: true,
+    description: 'Lọc theo trường hợp dịch vụ tại nhà',
+    type: Boolean,
+  })
+  async getAllServiceCasesForSampleCollector(
+    @Req() req: any,
+    @Query('isAtHome') isAtHome: boolean,
+  ): Promise<ApiResponseDto<ServiceCaseDocument>> {
+    const sampleCollectorId = req.user.id
+    const data =
+      await this.sampleCollectorService.getAllServiceCasesForSampleCollector(
+        sampleCollectorId,
+        isAtHome,
+      )
+    return {
+      data,
+      statusCode: 200,
+      message: 'Lấy tất cả trường hợp dịch vụ thành công',
+      success: true,
+    }
+  }
 }

--- a/Backend/src/modules/sampleCollector/sampleCollector.repository.ts
+++ b/Backend/src/modules/sampleCollector/sampleCollector.repository.ts
@@ -25,12 +25,17 @@ export class SampleCollectorRepository implements ISampleCollectorRepository {
     serviceCaseStatus: string,
     isAtHome: boolean,
   ): Promise<ServiceCaseDocument[]> {
+    const filter: any = {
+      sampleCollector: new Types.ObjectId(sampleCollectorId),
+    }
+
+    // Chỉ thêm điều kiện lọc currentStatus nếu nó không phải là chuỗi rỗng
+    if (serviceCaseStatus) {
+      filter.currentStatus = new Types.ObjectId(serviceCaseStatus)
+    }
     return this.serviceCaseModel.aggregate([
       {
-        $match: {
-          sampleCollector: new Types.ObjectId(sampleCollectorId),
-          currentStatus: new Types.ObjectId(serviceCaseStatus),
-        },
+        $match: filter,
       },
       {
         $lookup: {

--- a/Backend/src/modules/sampleCollector/sampleCollector.service.ts
+++ b/Backend/src/modules/sampleCollector/sampleCollector.service.ts
@@ -26,9 +26,26 @@ export class SampleCollectorService implements ISampleCollectorService {
     }
     return data
   }
+
   async getAllServiceCaseStatusForSampleCollector(): Promise<
     TestRequestStatusDocument[]
   > {
     return this.sampleCollectorRepository.getAllServiceCaseStatusForSampleCollector()
+  }
+
+  async getAllServiceCasesForSampleCollector(
+    sampleCollectorId: string,
+    isAtHome: boolean,
+  ): Promise<ServiceCaseDocument[]> {
+    const data =
+      await this.sampleCollectorRepository.getAllServiceCaseForSampleCollector(
+        sampleCollectorId,
+        '',
+        isAtHome,
+      )
+    if (!data || data.length === 0) {
+      throw new NotFoundException('Không tìm thấy trường hợp dịch vụ nào')
+    }
+    return data
   }
 }


### PR DESCRIPTION
Introduces endpoints and repository/service methods to fetch images by their creator and service cases for sample collectors, including filtering by 'at home' status. Updates interfaces to reflect new methods and improves query logic for service case retrieval.