### PR TITLE
Add serviceCaseId filter to findByCreatedBy methods

### DIFF
--- a/Backend/src/modules/image/image.controller.ts
+++ b/Backend/src/modules/image/image.controller.ts
@@ -11,6 +11,7 @@ import {
   Body,
   Inject,
   Req,
+  Query,
 } from '@nestjs/common'
 import { FileInterceptor } from '@nestjs/platform-express'
 import {
@@ -19,6 +20,7 @@ import {
   ApiTags,
   ApiParam,
   ApiBearerAuth,
+  ApiQuery,
 } from '@nestjs/swagger'
 import { ImageUploadService } from './imageUpload.service'
 import { AuthGuard } from 'src/common/guard/auth.guard'
@@ -182,9 +184,17 @@ export class ImageController {
   @Get('findForServiceCaseByCreatedBy')
   @UseGuards(AuthGuard)
   @ApiBearerAuth()
-  async findByCreatedBy(@Req() req: any) {
+  @ApiQuery({
+    name: 'serviceCaseId',
+    required: true,
+    description: 'ID của service case',
+  })
+  async findByCreatedBy(
+    @Req() req: any,
+    @Query('serviceCaseId') serviceCaseId: string,
+  ) {
     const userId = req.user.id
-    return this.uploadService.findByCreatedBy(userId)
+    return this.uploadService.findByCreatedBy(userId, serviceCaseId)
   }
 
   @Get(':id')

--- a/Backend/src/modules/image/imageUpload.repository.ts
+++ b/Backend/src/modules/image/imageUpload.repository.ts
@@ -128,9 +128,16 @@ export class ImageUploadRepository implements IImageUploadRepository {
     return result
   }
 
-  async findByCreatedBy(userId: string): Promise<ImageDocument[]> {
+  async findByCreatedBy(
+    userId: string,
+    serviceCaseId: string,
+  ): Promise<ImageDocument[]> {
     return await this.imageModel
-      .find({ created_by: userId, deleted_at: null })
+      .find({
+        created_by: userId,
+        serviceCase: serviceCaseId,
+        deleted_at: null,
+      })
       .lean()
       .exec()
   }

--- a/Backend/src/modules/image/imageUpload.service.ts
+++ b/Backend/src/modules/image/imageUpload.service.ts
@@ -196,8 +196,11 @@ export class ImageUploadService implements IImageUploadService {
     return true
   }
 
-  async findByCreatedBy(userId: string): Promise<ImageDocument[]> {
-    const data = await this.imageModel.findByCreatedBy(userId)
+  async findByCreatedBy(
+    userId: string,
+    serviceCaseId: string,
+  ): Promise<ImageDocument[]> {
+    const data = await this.imageModel.findByCreatedBy(userId, serviceCaseId)
 
     if (!data) {
       throw new NotFoundException('Không tìm thấy ảnh nào')

--- a/Backend/src/modules/image/interfaces/iImageUpload.service.ts
+++ b/Backend/src/modules/image/interfaces/iImageUpload.service.ts
@@ -41,7 +41,10 @@ export interface IImageUploadService {
 
   deleteById(id: string, userId: string): Promise<boolean>
 
-  findByCreatedBy(userId: string): Promise<ImageDocument[]>
+  findByCreatedBy(
+    userId: string,
+    serviceCaseId: string,
+  ): Promise<ImageDocument[]>
 }
 
 export const IImageUploadService = Symbol('IImageUploadService')

--- a/Backend/src/modules/image/interfaces/iimageUpload.repository.ts
+++ b/Backend/src/modules/image/interfaces/iimageUpload.repository.ts
@@ -40,7 +40,10 @@ export interface IImageUploadRepository {
 
   findAllImageForResult(kitShipmentId: string): Promise<ImageDocument[]>
 
-  findByCreatedBy(userId: string): Promise<ImageDocument[]>
+  findByCreatedBy(
+    userId: string,
+    serviceCaseId: string,
+  ): Promise<ImageDocument[]>
 }
 
 export const IImageUploadRepository = Symbol('IImageUploadRepository')


### PR DESCRIPTION
Updated controller, service, and repository to require and use a serviceCaseId parameter when fetching images by creator. This allows filtering images by both user and associated service case.