### PR TITLE
Update route to use serviceCaseId as URL param

### DIFF
--- a/Backend/src/modules/image/image.controller.ts
+++ b/Backend/src/modules/image/image.controller.ts
@@ -181,17 +181,17 @@ export class ImageController {
     return this.uploadService.findAllForServiceCase(serviceCaseId)
   }
 
-  @Get('findForServiceCaseByCreatedBy')
+  @Get('findForServiceCaseByCreatedBy/:serviceCaseId')
   @UseGuards(AuthGuard)
   @ApiBearerAuth()
-  @ApiQuery({
+  @ApiParam({
     name: 'serviceCaseId',
     required: true,
     description: 'ID của service case',
   })
   async findByCreatedBy(
     @Req() req: any,
-    @Query('serviceCaseId') serviceCaseId: string,
+    @Param('serviceCaseId') serviceCaseId: string,
   ) {
     const userId = req.user.id
     return this.uploadService.findByCreatedBy(userId, serviceCaseId)


### PR DESCRIPTION
Changed the 'findForServiceCaseByCreatedBy' endpoint to accept 'serviceCaseId' as a URL parameter instead of a query parameter. Updated decorator from @ApiQuery to @ApiParam and adjusted method signature accordingly for improved RESTful design.