### PR TITLE
Fix service list rendering and update account schema

### DIFF
--- a/Backend/src/modules/account/schemas/account.schema.ts
+++ b/Backend/src/modules/account/schemas/account.schema.ts
@@ -33,7 +33,7 @@ export class Account extends BaseEntity {
   @Prop({ type: Boolean, default: null })
   gender: boolean
 
-  @Prop({ type: String, default: null, unique: true })
+  @Prop({ type: String, default: null, unique: false })
   personalId: string
 
   @Prop({ type: Date, default: null })

--- a/WDP-FE/src/components/Admin/AdminService/ServiceList.tsx
+++ b/WDP-FE/src/components/Admin/AdminService/ServiceList.tsx
@@ -374,7 +374,7 @@ export default function ServiceList() {
           }}
         />
       )}
-      {data && (
+      {data ? (
         <div
           style={{
             padding: 24,
@@ -416,6 +416,11 @@ export default function ServiceList() {
           />
           <CreateServiceModelComponent />
         </div>
+      ) : (
+        <>
+          <ServiceHeader />
+          <CreateServiceModelComponent />
+        </>
       )}
     </div>
   )

--- a/WDP-FE/src/pages/ProfileUser/ServiceCaseDetail.tsx
+++ b/WDP-FE/src/pages/ProfileUser/ServiceCaseDetail.tsx
@@ -102,14 +102,14 @@ export default function ServiceCaseDetail() {
       align: 'right' as const,
       render: (services: any[], record: any) => {
         const serviceTotal = services?.reduce((sum, s) => sum + s.fee, 0)
-        const shippingFee = record.shippingFee
+        const shippingFee = record?.shippingFee
         const total = serviceTotal + shippingFee
         return (
           <Space direction='vertical'>
             {services?.map((service, index) => (
               <Text key={index}>{service.fee.toLocaleString('vi-VN')} ₫</Text>
             ))}
-            <Text>{shippingFee.toLocaleString('vi-VN')} ₫</Text>
+            <Text>{shippingFee?.toLocaleString('vi-VN')} ₫</Text>
             <Divider style={{ margin: '4px 0' }} />
             <Text strong>{total.toLocaleString('vi-VN')} ₫</Text>
           </Space>


### PR DESCRIPTION
Changed personalId in account schema to not be unique. Improved ServiceList rendering logic to handle cases when data is null, ensuring ServiceHeader and CreateServiceModelComponent are displayed. Added null checks for shippingFee in ServiceCaseDetail to prevent runtime errors.