### PR TITLE
Update test request status order ranges in services

### DIFF
--- a/Backend/src/modules/certifier/certifier.service.ts
+++ b/Backend/src/modules/certifier/certifier.service.ts
@@ -48,7 +48,7 @@ export class CertifierService implements ICertifierService {
   > {
     // Assuming there's a method in the repository to get test request statuses
     return this.testRequestStatusModel
-      .find({ order: { $in: [6, 7, 8, 9] } })
+      .find({ order: { $in: [5, 6, 7, 8] } })
       .sort({ order: 1 })
       .exec()
   }

--- a/Backend/src/modules/deliveryStaff/deliveryStaff.service.ts
+++ b/Backend/src/modules/deliveryStaff/deliveryStaff.service.ts
@@ -43,7 +43,7 @@ export class DeliveryStaffService implements IDeliveryStaffService {
     TestRequestStatusDocument[]
   > {
     return this.testRequestStatusModel
-      .find({ order: { $in: [9, 10] } })
+      .find({ order: { $in: [8, 9, 10] } })
       .sort({ order: 1 })
       .lean()
       .exec()

--- a/Backend/src/modules/doctor/doctor.service.ts
+++ b/Backend/src/modules/doctor/doctor.service.ts
@@ -41,7 +41,7 @@ export class DoctorService implements IDoctorService {
 
   async getDoctorTestRequestStatuses(): Promise<TestRequestStatusDocument[]> {
     return this.testRequestStatusModel
-      .find({ order: { $in: [6, 7, 8, 9] } })
+      .find({ order: { $in: [5, 6, 7, 8] } })
       .sort({ order: 1 })
       .lean()
       .exec()

--- a/Backend/src/modules/sampleCollector/sampleCollector.repository.ts
+++ b/Backend/src/modules/sampleCollector/sampleCollector.repository.ts
@@ -306,7 +306,7 @@ export class SampleCollectorRepository implements ISampleCollectorRepository {
   > {
     return this.testRequestStatusModel
       .find({
-        order: { $in: [2, 3, 4, 5, 6] },
+        order: { $in: [1, 2, 3, 4, 5] },
       })
       .sort({ order: 1 })
       .lean()


### PR DESCRIPTION
Adjusted the 'order' ranges for test request status queries in certifier, doctor, delivery staff services, and sample collector repository to reflect updated business logic or workflow requirements.