### PR TITLE
Include created_at field in staff aggregation

### DIFF
--- a/Backend/src/modules/staff/staff.repository.ts
+++ b/Backend/src/modules/staff/staff.repository.ts
@@ -222,6 +222,7 @@ export class StaffRepository implements IStaffRepository {
           currentStatus: '$currentStatus.testRequestStatus',
           adnDocumentation: 1,
           result: 1,
+          created_at: 1,
           bookingDetails: {
             bookingDate: '$bookings.bookingDate',
             slotTime: '$slots.startTime',


### PR DESCRIPTION
Added the created_at field to the aggregation projection in StaffRepository to ensure it is returned in query results. This change allows consumers to access the creation timestamp for staff records.