### PR TITLE
Improve forms and error handling in certifier and service pages

### DIFF
--- a/WDP-FE/src/components/Certifier/DocumentFormAccept.tsx
+++ b/WDP-FE/src/components/Certifier/DocumentFormAccept.tsx
@@ -11,6 +11,7 @@ import {
   Button,
   message,
   Modal,
+  InputNumber,
 } from 'antd'
 import Cookies from 'js-cookie'
 import {
@@ -33,7 +34,7 @@ export default function DocumentFormAccept() {
   const location = useLocation()
   const serviceCase = location.state?.serviceCase
 
-  const [adnPercentage, setAdnPercentage] = useState('')
+  const [adnPercentage, setAdnPercentage] = useState()
   const [conclusion, setConclusion] = useState('')
   const [createResult, { isLoading: isSubmitting }] =
     useCreateCertifierResultMutation()
@@ -149,11 +150,18 @@ export default function DocumentFormAccept() {
 
           <Col span={24}>
             <Card title='📝 Nhập kết quả giám định'>
-              <Input
+              <InputNumber
                 addonBefore='% trùng khớp'
                 value={adnPercentage}
-                onChange={(e) => setAdnPercentage(e.target.value)}
+                // ✅ 2. Đơn giản hóa hàm onChange
+                onChange={(value) => setAdnPercentage(value)}
                 placeholder='Ví dụ: 99.999'
+                // ✅ 1. Sửa max và min thành kiểu number
+                max={100}
+                min={0}
+                stringMode
+                step={0.001}
+                style={{ width: '100%' }} // Thêm style để input rộng hơn nếu cần
               />
               <TextArea
                 style={{ marginTop: 12 }}

--- a/WDP-FE/src/components/Certifier/DoneDocumentForm.tsx
+++ b/WDP-FE/src/components/Certifier/DoneDocumentForm.tsx
@@ -157,6 +157,10 @@ export default function DoneDocumentForm() {
                   <strong>Ghi chú:</strong>{' '}
                   {result?.conclusion ?? 'Không có dữ liệu'}
                 </p>
+                <p>
+                  <strong>Người duyệt kết quả:</strong>{' '}
+                  {result?.certifierId.name ?? 'Không có dữ liệu'}
+                </p>
               </Card>
             </Col>
 

--- a/WDP-FE/src/components/ServiceAtHome/serviceAtHome.tsx
+++ b/WDP-FE/src/components/ServiceAtHome/serviceAtHome.tsx
@@ -19,9 +19,7 @@ interface TestTakerListResponse {
   isLoading: boolean
 }
 
-
 const ServiceAtHomeForm: React.FC = () => {
-
   const accountId = Cookies.get('userData')
     ? JSON.parse(Cookies.get('userData') as string).id
     : undefined
@@ -44,17 +42,23 @@ const ServiceAtHomeForm: React.FC = () => {
     pageNumber: 1,
   })
 
-
   // Lấy danh sách dịch vụ cho việc chọn
-  const { data: serviceListData, isLoading: isLoadingServices, error: serviceError } = useGetServiceListQuery({
-    pageNumber: 1,
-    pageSize: 100,
-    isAdministration: false,
-    isSelfSampling: isSelfSampling,
-    isAgnate: showAgnate, // Sử dụng API query theo isAgnate
-  }, {
-    refetchOnMountOrArgChange: true, // Refetch khi component mount hoặc argument thay đổi
-  })
+  const {
+    data: serviceListData,
+    isLoading: isLoadingServices,
+    error: serviceError,
+  } = useGetServiceListQuery(
+    {
+      pageNumber: 1,
+      pageSize: 100,
+      isAdministration: false,
+      isSelfSampling: isSelfSampling,
+      isAgnate: showAgnate, // Sử dụng API query theo isAgnate
+    },
+    {
+      refetchOnMountOrArgChange: true, // Refetch khi component mount hoặc argument thay đổi
+    }
+  )
 
   const serviceList = serviceListData?.data || []
   const [createCaseMember, { isLoading: isCreating }] =
@@ -90,7 +94,10 @@ const ServiceAtHomeForm: React.FC = () => {
     return dataTestTaker.filter((taker) => !selectedIds.includes(taker._id))
   }
 
-  const isServiceDisabled = (serviceId: string, currentServiceField: string) => {
+  const isServiceDisabled = (
+    serviceId: string,
+    currentServiceField: string
+  ) => {
     const selectedServiceIds = Object.keys(selectedTestTakers || {})
       .filter((key) => key.startsWith('service') && key !== currentServiceField)
       .map((key) => selectedTestTakers[key])
@@ -106,16 +113,10 @@ const ServiceAtHomeForm: React.FC = () => {
     const accountId = decoded?.id || decoded?._id
     if (!accountId) return message.error('Không xác định được tài khoản')
 
-    const testTakers = [
-      values.testTaker1,
-      values.testTaker2,
-    ].filter((id) => id)
+    const testTakers = [values.testTaker1, values.testTaker2].filter((id) => id)
 
     const services = isSingle
-      ? [
-        values.service1,
-        values.service2,
-      ].filter((id) => id)
+      ? [values.service1, values.service2].filter((id) => id)
       : values.sharedServices || [] // Sử dụng sharedServices khi isSingle = false
 
     const { slot } = values
@@ -152,7 +153,9 @@ const ServiceAtHomeForm: React.FC = () => {
       }
 
       if (isSelfSampling) {
-        const response = await createKitShipment({ caseMember: caseMemberId }).unwrap()
+        const response = await createKitShipment({
+          caseMember: caseMemberId,
+        }).unwrap()
         console.log('Kit shipment created:', response)
       }
 
@@ -195,35 +198,55 @@ const ServiceAtHomeForm: React.FC = () => {
       }}
     >
       <div style={{ width: '100%', maxWidth: '100%' }}>
-        <div
-          style={{ maxWidth: 800, margin: '0 auto', padding: '20px' }}>
-          <div style={{ display: 'flex', justifyContent: 'center', marginBottom: '20px' }}>
+        <div style={{ maxWidth: 800, margin: '0 auto', padding: '20px' }}>
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'center',
+              marginBottom: '20px',
+            }}
+          >
             <Radio.Group
               onChange={(e) => setIsSingle(e.target.value)}
               value={isSingle}
             >
-              <Radio value={true}>Single service</Radio>
-              <Radio value={false}>Multiple services</Radio>
+              <Radio value={true}>Mỗi người một dịch vụ</Radio>
+              <Radio value={false}>Nhiều dịch vụ</Radio>
             </Radio.Group>
           </div>
 
-
-          <div style={{ display: 'flex', justifyContent: 'flex-start', marginBottom: '20px' }}>
-            <p style={{ marginTop: "0", marginRight: "8px" }}>Chọn bên xét nghiệm:</p>
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'flex-start',
+              marginBottom: '20px',
+            }}
+          >
+            <p style={{ marginTop: '0', marginRight: '8px' }}>
+              Chọn bên xét nghiệm:
+            </p>
             <Switch
               checked={showAgnate}
               onChange={(checked) => setShowAgnate(checked)}
-              checkedChildren="Bên nội"
-              unCheckedChildren="Bên ngoại"
+              checkedChildren='Bên nội'
+              unCheckedChildren='Bên ngoại'
             />
           </div>
-          <div style={{ display: 'flex', justifyContent: 'flex-start', marginBottom: '20px' }}>
-            <p style={{ marginTop: "0", marginRight: "8px" }}>Chọn hình thức lấy mẫu:</p>
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'flex-start',
+              marginBottom: '20px',
+            }}
+          >
+            <p style={{ marginTop: '0', marginRight: '8px' }}>
+              Chọn hình thức lấy mẫu:
+            </p>
             <Switch
               checked={isSelfSampling}
               onChange={(checked) => setIsSelfSampling(checked)}
-              checkedChildren="Không tự lấy mẫu"
-              unCheckedChildren="Tự lấy mẫu"
+              checkedChildren='Không tự lấy mẫu'
+              unCheckedChildren='Tự lấy mẫu'
             />
           </div>
         </div>

--- a/WDP-FE/src/pages/CertifierManage/ServiceCaseNeedAcceptAdn.tsx
+++ b/WDP-FE/src/pages/CertifierManage/ServiceCaseNeedAcceptAdn.tsx
@@ -73,7 +73,7 @@ export default function ServiceCaseNeedAcceptAdn() {
     error,
   } = useGetServiceCasesWithoutResultQuery(
     // ✅ 2. Sử dụng trực tiếp ID của trạng thái đầu tiên
-    { currentStatus: firstStatusId, resultExists: true },
+    { currentStatus: firstStatusId, resultExists: false },
     { skip: !firstStatusId } // Không chạy query khi chưa có ID
   )
 

--- a/WDP-FE/src/pages/DeliveryStaffHomePage/DeliveryStaffKitShipment.tsx
+++ b/WDP-FE/src/pages/DeliveryStaffHomePage/DeliveryStaffKitShipment.tsx
@@ -42,12 +42,12 @@ const DeliveryStaffKitShipment: React.FC = () => {
 
   // Status IDs constants
   const STATUS_IDS = {
-    CONFIRMED: '688104fd5153ca0a75de9a67',
-    DELIVERED: '688105125153ca0a75de9a6a',
-    CANCELLED: '688105695153ca0a75de9a80',
-    SAMPLE_SUCCESS: '688105205153ca0a75de9a72',
-    SAMPLE_FAILED: '688105775153ca0a75de9a83',
-    DELIVERED_TO_FACILITY: '688105455153ca0a75de9a75',
+    CONFIRMED: '688f57ffead5d391225cafea',
+    DELIVERED: '688f57ffead5d391225cafeb',
+    CANCELLED: '688f57ffead5d391225cafef',
+    SAMPLE_SUCCESS: '688f57ffead5d391225cafec',
+    SAMPLE_FAILED: '688f57ffead5d391225caff0',
+    DELIVERED_TO_FACILITY: '688f57ffead5d391225cafed',
   }
 
   // Generic status update handler

--- a/WDP-FE/src/pages/DoctorServiceCaseWithoutResult/ServiceCaseAlreadyHasAdn.tsx
+++ b/WDP-FE/src/pages/DoctorServiceCaseWithoutResult/ServiceCaseAlreadyHasAdn.tsx
@@ -62,11 +62,15 @@ export default function ServiceCaseAlreadyHasAdn() {
     error,
   } = useGetAllRequestStatusListQuery({ pageNumber: 1, pageSize: 100 })
 
-  const { data: serviceCaseData, isLoading } =
-    useGetServiceCasesWithoutAdnQuery(
-      { currentStatus: selectedStatus, resultExists },
-      { skip: !selectedStatus }
-    )
+  const {
+    data: serviceCaseData,
+    isLoading,
+    isError: isErrorServiceCase,
+    error: serviceCaseError,
+  } = useGetServiceCasesWithoutAdnQuery(
+    { currentStatus: selectedStatus, resultExists },
+    { skip: !selectedStatus }
+  )
 
   const allStatuses = useMemo(
     () => (statusData?.data as RequestStatus[])?.slice(2) || [],
@@ -194,6 +198,24 @@ export default function ServiceCaseAlreadyHasAdn() {
     const errorMessage = apiError?.data?.message || 'Có lỗi xảy ra'
     const errorStatus = apiError?.status || 'Lỗi'
 
+    return (
+      <div style={{ padding: 24 }}>
+        <Title level={3}>📄 Hồ sơ chưa có tài liệu ADN</Title>
+        <FilterSection />
+        <Result
+          status={errorStatus === 404 ? '404' : 'error'}
+          title={errorStatus}
+          subTitle={errorMessage}
+          style={{ marginTop: '20px' }}
+        />
+      </div>
+    )
+  }
+
+  if (isErrorServiceCase) {
+    const apiError = serviceCaseError as any
+    const errorMessage = apiError?.data?.message || 'Có lỗi xảy ra'
+    const errorStatus = apiError?.status || 'Lỗi'
     return (
       <div style={{ padding: 24 }}>
         <Title level={3}>📄 Hồ sơ chưa có tài liệu ADN</Title>


### PR DESCRIPTION
Refactored DocumentFormAccept to use InputNumber for percentage input and improved its configuration. Added certifier name display in DoneDocumentForm. Enhanced ServiceAtHome form UI and code formatting. Fixed ServiceCaseNeedAcceptAdn query to fetch cases without results. Updated status IDs in DeliveryStaffKitShipment. Improved error handling in ServiceCaseAlreadyHasAdn to show API error messages.