### PR TITLE
Add staff listing and account deletion endpoints

### DIFF
--- a/Backend/src/modules/account/interfaces/iaccount.response.ts
+++ b/Backend/src/modules/account/interfaces/iaccount.response.ts
@@ -14,6 +14,7 @@ export interface AccountBase {
   facility: Types.ObjectId | string
   gender: boolean
   password: string
+  deleted_at?: Date | null
 }
 
 export interface LeanPopulatedAccount extends Omit<AccountBase, 'role'> {

--- a/Backend/src/modules/auth/auth.service.ts
+++ b/Backend/src/modules/auth/auth.service.ts
@@ -68,6 +68,10 @@ export class AuthService {
       throw new NotFoundException('Tài khoản không tồn tại')
     }
 
+    if (account.deleted_at) {
+      throw new HttpException('Tài khoản đã bị xóa', HttpStatus.BAD_REQUEST)
+    }
+
     const isPasswordValid = await this.comparePassword(
       password,
       account.password,

--- a/Backend/src/modules/manager/interfaces/imanager.repository.ts
+++ b/Backend/src/modules/manager/interfaces/imanager.repository.ts
@@ -68,6 +68,18 @@ export interface IManagerRepository {
     deliveryStaffId: string,
     userId: string,
   ): Promise<ServiceCaseDocument>
+
+  getAllStaffs(
+    facilityId: string,
+    userRole: string,
+    email?: string,
+    role?: string,
+  ): Promise<AccountDocument[]>
+
+  deleteAccount(
+    accountId: string,
+    userId: string,
+  ): Promise<AccountDocument | null>
 }
 
 export const IManagerRepository = Symbol('IManagerRepository')

--- a/Backend/src/modules/manager/interfaces/imanager.service.ts
+++ b/Backend/src/modules/manager/interfaces/imanager.service.ts
@@ -63,6 +63,15 @@ export interface IManagerService {
     facilityId: string,
     bookingDate: string,
   ): Promise<ServiceCaseResponseDto[]>
+
+  getAllStaffs(
+    facilityId: string,
+    userRole: string,
+    email?: string,
+    role?: string,
+  ): Promise<AccountResponseDto[]>
+
+  deleteAccount(accountId: string, userId: string): Promise<AccountResponseDto>
 }
 
 export const IManagerService = Symbol('IManagerService')

--- a/Backend/src/modules/manager/manager.controller.ts
+++ b/Backend/src/modules/manager/manager.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
   HttpStatus,
   Inject,
@@ -44,6 +45,48 @@ export class ManagerController {
     @Inject(IManagerService)
     private readonly managerService: IManagerService,
   ) {}
+
+  @Get('staffs')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Lấy danh sách nhân viên' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Danh sách nhân viên',
+    type: AccountResponseDto,
+    isArray: true,
+  })
+  @ApiQuery({
+    name: 'email',
+    required: false,
+    type: String,
+    description: 'Lọc theo email của nhân viên',
+  })
+  @ApiQuery({
+    name: 'role',
+    required: false,
+    type: String,
+    description: 'Lọc theo vai trò của nhân viên (truyền id của vai trò)',
+  })
+  async getAllStaffs(
+    @Req() req: any,
+    @Query('email') email?: string,
+    @Query('role') role?: string,
+  ): Promise<ApiResponseDto<AccountResponseDto>> {
+    const facilityId = req.user.facility._id
+    const userRole = req.user.role
+    const data = await this.managerService.getAllStaffs(
+      facilityId,
+      userRole,
+      email,
+      role,
+    )
+    return {
+      statusCode: HttpStatus.OK,
+      success: true,
+      message: 'Danh sách nhân viên',
+      data: data.map((item) => new AccountResponseDto(item)),
+    }
+  }
 
   @Get('sample-collectors')
   @ApiBearerAuth()
@@ -450,6 +493,33 @@ export class ManagerController {
       success: true,
       message: 'Danh sách vai trò',
       data: data,
+    }
+  }
+
+  @Delete('accounts/:accountId')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Xóa tài khoản' })
+  @ApiParam({
+    name: 'accountId',
+    description: 'ID của tài khoản cần xóa',
+    required: true,
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Xóa tài khoản thành công',
+    type: ApiResponseDto<AccountResponseDto>,
+  })
+  async deleteAccount(
+    @Param('accountId') accountId: string,
+    @Req() req: any,
+  ): Promise<ApiResponseDto<AccountResponseDto>> {
+    const userId = req.user.id
+    const data = await this.managerService.deleteAccount(accountId, userId)
+    return {
+      statusCode: HttpStatus.OK,
+      success: true,
+      message: 'Xóa tài khoản thành công',
+      data: [data],
     }
   }
 }

--- a/Backend/src/modules/manager/manager.service.ts
+++ b/Backend/src/modules/manager/manager.service.ts
@@ -213,4 +213,36 @@ export class ManagerService implements IManagerService {
     }
     return serviceCases.map((item) => new ServiceCaseResponseDto(item))
   }
+
+  async getAllStaffs(
+    facilityId: string,
+    userRole: string,
+    email?: string,
+    role?: string,
+  ): Promise<AccountResponseDto[]> {
+    const staffs = await this.managerRepository.getAllStaffs(
+      facilityId,
+      userRole,
+      email,
+      role,
+    )
+    if (!staffs || staffs.length === 0) {
+      throw new NotFoundException('Không tìm thấy nhân viên nào')
+    }
+    return staffs.map((item) => new AccountResponseDto(item))
+  }
+
+  async deleteAccount(
+    accountId: string,
+    userId: string,
+  ): Promise<AccountResponseDto> {
+    const deletedAccount = await this.managerRepository.deleteAccount(
+      accountId,
+      userId,
+    )
+    if (!deletedAccount) {
+      throw new NotFoundException('Không tìm thấy tài khoản để xóa')
+    }
+    return new AccountResponseDto(deletedAccount)
+  }
 }


### PR DESCRIPTION
Introduces endpoints to list all staff with optional filters and to soft-delete accounts in the manager module. Updates interfaces, repository, and service layers to support these features, and adds a deleted_at field to the account response. Also prevents login for deleted accounts in the auth service.