### PR TITLE
Include deleted_at in manager responses

### DIFF
--- a/Backend/src/modules/manager/manager.repository.ts
+++ b/Backend/src/modules/manager/manager.repository.ts
@@ -1055,6 +1055,7 @@ export class ManagerRepository implements IManagerRepository {
           name: 1,
           phoneNumber: 1,
           role: '$role.role',
+          deleted_at: 1,
         },
       },
     ])

--- a/Backend/src/modules/manager/manager.service.ts
+++ b/Backend/src/modules/manager/manager.service.ts
@@ -24,6 +24,7 @@ export class ManagerService implements IManagerService {
       phoneNumber: user.phoneNumber,
       role: user.role,
       facility: user.facility,
+      deleted_at: user.deleted_at,
     })
   }
 
@@ -229,7 +230,7 @@ export class ManagerService implements IManagerService {
     if (!staffs || staffs.length === 0) {
       throw new NotFoundException('Không tìm thấy nhân viên nào')
     }
-    return staffs.map((item) => new AccountResponseDto(item))
+    return staffs.map((item) => this.mapToResponseDto(item))
   }
 
   async deleteAccount(
@@ -243,6 +244,6 @@ export class ManagerService implements IManagerService {
     if (!deletedAccount) {
       throw new NotFoundException('Không tìm thấy tài khoản để xóa')
     }
-    return new AccountResponseDto(deletedAccount)
+    return this.mapToResponseDto(deletedAccount)
   }
 }


### PR DESCRIPTION
Added the deleted_at field to manager repository projections and service response DTOs to ensure soft-deleted status is available in API responses. Also refactored service methods to consistently use mapToResponseDto for mapping.