### PR TITLE
Add CUSTOMER role to service case status update

### DIFF
--- a/Backend/src/modules/kitShipmentHistory/kitShipmentHistory.repository.ts
+++ b/Backend/src/modules/kitShipmentHistory/kitShipmentHistory.repository.ts
@@ -9,11 +9,12 @@ import { IKitShipmentHistoryRepository } from './interfaces/iKitShipmentHistory.
 
 @Injectable()
 export class KitShipmentHistoryRepository
-  implements IKitShipmentHistoryRepository {
+  implements IKitShipmentHistoryRepository
+{
   constructor(
     @InjectModel(KitShipmentHistory.name)
     private KitShipmentHistoryModel: Model<KitShipmentHistoryDocument>,
-  ) { }
+  ) {}
 
   async createKitShipmentHistory(
     kitShipmentStatus: string,
@@ -33,11 +34,12 @@ export class KitShipmentHistoryRepository
     filter: Record<string, unknown>,
   ): mongoose.Query<KitShipmentHistoryDocument[], KitShipmentHistoryDocument> {
     // Return as promise for better debugging
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     return this.KitShipmentHistoryModel.find(filter)
       .populate({
         path: 'kitShipmentStatus',
         select: 'status order -_id',
-        match: { order: { $in: [2, 3, 4, 6] } }
+        match: { order: { $in: [2, 3, 4, 6] } },
       })
       .select('_id kitShipmentStatus kitShipment created_at')
       .lean() as any

--- a/Backend/src/modules/serviceCase/serviceCase.controller.ts
+++ b/Backend/src/modules/serviceCase/serviceCase.controller.ts
@@ -100,6 +100,7 @@ export class ServiceCaseController {
     RoleEnum.DOCTOR,
     RoleEnum.SAMPLE_COLLECTOR,
     RoleEnum.STAFF,
+    RoleEnum.CUSTOMER,
   )
   @ApiOperation({ summary: 'Cập nhật trạng thái hiện tại của hồ sơ dịch vụ' })
   @ApiParam({


### PR DESCRIPTION
Included RoleEnum.CUSTOMER in the allowed roles for updating the current status of a service case. Minor formatting improvements were also made in kitShipmentHistory.repository.ts for readability.